### PR TITLE
Resolver should resolve through links

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,9 @@ module.exports = class IPLDResolver {
 
     until(
       () => {
-        if (!path || path === '' || path === '/') {
+        const endReached = !path || path === '' || path === '/'
+        const isLink = value && !value['/']
+        if (endReached && isLink) {
           return true
         } else {
           // continue traversing

--- a/src/index.js
+++ b/src/index.js
@@ -59,8 +59,8 @@ module.exports = class IPLDResolver {
     until(
       () => {
         const endReached = !path || path === '' || path === '/'
-        const isLink = value && !value['/']
-        if (endReached && isLink) {
+        const isTerminal = value && !value['/']
+        if (endReached && isTerminal) {
           return true
         } else {
           // continue traversing

--- a/test/test-ipld-dag-cbor.js
+++ b/test/test-ipld-dag-cbor.js
@@ -214,6 +214,16 @@ module.exports = (repo) => {
       })
     })
 
+    it('value within nested scope (0 level)', (done) => {
+      resolver.resolve(cid2, 'one', (err, result) => {
+        expect(result).to.eql({
+          someData: 'I am 1'
+        })
+        done()
+      })
+    })
+
+
     it('value within nested scope (1 level)', (done) => {
       resolver.resolve(cid2, 'one/someData', (err, result) => {
         expect(err).to.not.exist

--- a/test/test-ipld-dag-cbor.js
+++ b/test/test-ipld-dag-cbor.js
@@ -216,13 +216,13 @@ module.exports = (repo) => {
 
     it('value within nested scope (0 level)', (done) => {
       resolver.resolve(cid2, 'one', (err, result) => {
+        expect(err).to.not.exist
         expect(result).to.eql({
           someData: 'I am 1'
         })
         done()
       })
     })
-
 
     it('value within nested scope (1 level)', (done) => {
       resolver.resolve(cid2, 'one/someData', (err, result) => {


### PR DESCRIPTION
cid1
```
{
  someData: 'I am 1'
}
```

cid2
```
{
  someData: 'I am 3',
  one: { '/': cid1 },
  two: { '/': cid2 }
}
```

```
/someData == 'I am 3'
/one/someData === 'I am 1'
```

Everything is correct so far, however

```
/one must be === { someData: 'I am 1' }
// instead of
/one === { '/': cid1 },
```

---

**Update**: I fixed it in this PR