### PR TITLE
Absolute, relative paths and other edge cases

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const until = require('async/until')
 const IPFSRepo = require('ipfs-repo')
 const MemoryStore = require('interface-pull-blob-store')
 const BlockService = require('ipfs-block-service')
+const joinPath = require('path').join
 
 const dagPB = require('ipld-dag-pb')
 const dagCBOR = require('ipld-dag-cbor')
@@ -50,7 +51,11 @@ module.exports = class IPLDResolver {
   }
 
   resolve (cid, path, callback) {
-    if (path === '/') {
+    // this removes occurrences of ./, //, ../
+    // makes sure that path never starts with ./ or /
+    path = joinPath('/', path).substr(1)
+
+    if (path === '') {
       return this.get(cid, callback)
     }
 

--- a/test/test-ipld-dag-cbor.js
+++ b/test/test-ipld-dag-cbor.js
@@ -206,6 +206,62 @@ module.exports = (repo) => {
       })
     })
 
+    it('relative path `.` (same as get /)', (done) => {
+      resolver.resolve(cid1, '.', (err, result) => {
+        expect(err).to.not.exist
+
+        dagCBOR.util.cid(result, (err, cid) => {
+          expect(err).to.not.exist
+          expect(cid).to.eql(cid1)
+          done()
+        })
+      })
+    })
+
+    it('relative path `./` (same as get /)', (done) => {
+      resolver.resolve(cid1, './', (err, result) => {
+        expect(err).to.not.exist
+
+        dagCBOR.util.cid(result, (err, cid) => {
+          expect(err).to.not.exist
+          expect(cid).to.eql(cid1)
+          done()
+        })
+      })
+    })
+
+    it('relative path `./one/someData` (same as get one/someData)', (done) => {
+      resolver.resolve(cid2, './one/someData', (err, result) => {
+        expect(err).to.not.exist
+        expect(result).to.eql('I am 1')
+        done()
+      })
+    })
+
+    it('relative path `one/./someData` (same as get one/someData)', (done) => {
+      resolver.resolve(cid2, 'one/./someData', (err, result) => {
+        expect(err).to.not.exist
+        expect(result).to.eql('I am 1')
+        done()
+      })
+    })
+
+    it('double slash at the beginning `//one/someData` (same as get one/someData)', (done) => {
+      resolver.resolve(cid2, '//one/someData', (err, result) => {
+        expect(err).to.not.exist
+        expect(result).to.eql('I am 1')
+        done()
+      })
+    })
+
+    it('double slash in the middle `one//someData` (same as get one/someData)', (done) => {
+      resolver.resolve(cid2, 'one//someData', (err, result) => {
+        expect(err).to.not.exist
+        expect(result).to.eql('I am 1')
+        done()
+      })
+    })
+
     it('value within 1st node scope', (done) => {
       resolver.resolve(cid1, 'someData', (err, result) => {
         expect(err).to.not.exist


### PR DESCRIPTION
With this PR paths in the resolver can
- start with `/`, with `./`, be `''`, or start with the name of an attribute
- contain `./`, `//`, `../`, since it will be normalized the way a path would be